### PR TITLE
Auto-migrate database in dev, fix allowedDevOrigins, add tests

### DIFF
--- a/apps/api/src/fresh-db.test.ts
+++ b/apps/api/src/fresh-db.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+import { createDb } from "@min-claude/db";
+import { app } from "./app";
+
+describe("API with fresh auto-migrated database", () => {
+  it("health endpoint responds", async () => {
+    const db = createDb(":memory:");
+    const server = app(db);
+    const res = await server.request("/health");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ status: "ok" });
+  });
+
+  it("GET /api/projects returns empty array on fresh database", async () => {
+    const db = createDb(":memory:");
+    const server = app(db);
+    const res = await server.request("/api/projects");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@min-claude/shared"],
+  allowedDevOrigins: ["localhost"],
 };
 
 export default nextConfig;

--- a/packages/db/src/auto-migrate.test.ts
+++ b/packages/db/src/auto-migrate.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { createDb } from "./client";
+
+describe("auto-migration", () => {
+  let originalNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  function getTableNames(dbPath: string): string[] {
+    const sqlite = new Database(dbPath);
+    const rows = sqlite
+      .query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '__drizzle%' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as { name: string }[];
+    sqlite.close();
+    return rows.map((r) => r.name);
+  }
+
+  it("creates all tables on a fresh in-memory database", () => {
+    process.env.NODE_ENV = "development";
+    const db = createDb(":memory:");
+    const tables = db.run(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '__drizzle%' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    );
+    // Use raw SQL to check tables since we have the db instance
+    const sqlite = (db as any).$client as Database;
+    const rows = sqlite
+      .query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '__drizzle%' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as { name: string }[];
+    const tableNames = rows.map((r) => r.name);
+
+    expect(tableNames).toContain("projects");
+    expect(tableNames).toContain("prds");
+    expect(tableNames).toContain("messages");
+  });
+
+  it("is idempotent — second call causes no errors or data loss", () => {
+    process.env.NODE_ENV = "development";
+    // Use a temp file so both calls access the same database
+    const tmpPath = `/tmp/min-claude-test-idempotent-${Date.now()}.db`;
+
+    const db1 = createDb(tmpPath);
+    // Insert a project
+    db1.run(
+      "INSERT INTO projects (name, path, created_at, updated_at) VALUES ('Test', '/test', unixepoch(), unixepoch())",
+    );
+
+    // Second call — should not error or lose data
+    const db2 = createDb(tmpPath);
+    const sqlite2 = (db2 as any).$client as Database;
+    const rows = sqlite2
+      .query("SELECT name FROM projects")
+      .all() as { name: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("Test");
+
+    // Cleanup
+    (db1 as any).$client.close();
+    sqlite2.close();
+    require("fs").unlinkSync(tmpPath);
+  });
+
+  it("does NOT auto-migrate when NODE_ENV=production", () => {
+    process.env.NODE_ENV = "production";
+    const db = createDb(":memory:");
+
+    const sqlite = (db as any).$client as Database;
+    const rows = sqlite
+      .query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as { name: string }[];
+    const tableNames = rows.map((r) => r.name);
+
+    // Should have no application tables (no migrations ran)
+    expect(tableNames).not.toContain("projects");
+    expect(tableNames).not.toContain("prds");
+    expect(tableNames).not.toContain("messages");
+  });
+});

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,12 +1,27 @@
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Database } from "bun:sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { resolve } from "path";
 import * as schema from "./schema";
 
-export function createDb(dbPath?: string) {
+const defaultMigrationsFolder = resolve(import.meta.dir, "../drizzle");
+
+export function createDb(
+  dbPath?: string,
+  options?: { migrationsFolder?: string },
+) {
   const sqlite = new Database(dbPath ?? process.env.DB_PATH ?? "local.db");
   sqlite.exec("PRAGMA journal_mode = WAL;");
   sqlite.exec("PRAGMA foreign_keys = ON;");
-  return drizzle(sqlite, { schema });
+  const db = drizzle(sqlite, { schema });
+
+  if (process.env.NODE_ENV !== "production") {
+    migrate(db, {
+      migrationsFolder: options?.migrationsFolder ?? defaultMigrationsFolder,
+    });
+  }
+
+  return db;
 }
 
 export type Db = ReturnType<typeof createDb>;


### PR DESCRIPTION
## Summary
- **Auto-migrate database in dev mode**: `createDb()` now auto-applies pending Drizzle migrations when `NODE_ENV !== 'production'`, making `bun run dev` fully self-bootstrapping
- **Fix allowedDevOrigins**: Added `allowedDevOrigins: ["localhost"]` to `next.config.ts` to suppress cross-origin dev warnings
- **Tests**: Added DB unit tests (fresh migration, idempotency, production guard) and API integration tests (health endpoint, empty projects on fresh DB)

Closes #14

## Test plan
- [x] DB: fresh in-memory DB gets all expected tables after `createDb()`
- [x] DB: second call to `createDb()` on same DB is idempotent
- [x] DB: `NODE_ENV=production` skips auto-migration
- [x] API: health endpoint responds on fresh DB
- [x] API: `GET /api/projects` returns `[]` on fresh DB
- [x] All existing tests continue to pass (72 total)
- [x] Type checks pass across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)