### PR TITLE
Create apps/e2e workspace with Playwright and mock Agent SDK

### DIFF
--- a/apps/api/src/agent/agent-sdk.ts
+++ b/apps/api/src/agent/agent-sdk.ts
@@ -1,0 +1,28 @@
+/**
+ * Agent SDK adapter — re-exports query/tool/createSdkMcpServer from either
+ * the real @anthropic-ai/claude-agent-sdk or the mock, depending on MOCK_AGENT env var.
+ */
+import type {
+  SDKMessage,
+  SDKResultMessage,
+  Query,
+} from "@anthropic-ai/claude-agent-sdk";
+import type * as RealSDK from "@anthropic-ai/claude-agent-sdk";
+
+type SDK = Pick<typeof RealSDK, "query" | "tool" | "createSdkMcpServer">;
+
+let sdkModule: SDK;
+
+if (process.env.MOCK_AGENT === "true") {
+  sdkModule = (await import("./mock-agent-sdk")) as unknown as SDK;
+} else {
+  sdkModule = await import("@anthropic-ai/claude-agent-sdk");
+}
+
+export const query: SDK["query"] = sdkModule.query;
+export const tool: SDK["tool"] = sdkModule.tool;
+export const createSdkMcpServer: SDK["createSdkMcpServer"] =
+  sdkModule.createSdkMcpServer;
+
+// Re-export types from the real SDK for use in agent-service.ts
+export type { SDKMessage, SDKResultMessage, Query };

--- a/apps/api/src/agent/agent-service.test.ts
+++ b/apps/api/src/agent/agent-service.test.ts
@@ -10,10 +10,10 @@ import {
 import { WsHub } from "../ws/hub";
 import { AskUserBridge } from "./ask-user-bridge";
 
-// Mock the @anthropic-ai/claude-agent-sdk module
+// Mock the agent-sdk adapter module (which proxies to real or mock SDK)
 const mockQueryFn = mock(() => {});
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+mock.module("./agent-sdk", () => ({
   query: mockQueryFn,
   tool: mock(
     (

--- a/apps/api/src/agent/agent-service.ts
+++ b/apps/api/src/agent/agent-service.ts
@@ -5,7 +5,7 @@ import {
   type SDKMessage,
   type SDKResultMessage,
   type Query,
-} from "@anthropic-ai/claude-agent-sdk";
+} from "./agent-sdk";
 import { z } from "zod";
 import type { Db } from "@min-claude/db";
 import { createMessage, updatePrdSessionId } from "@min-claude/db";

--- a/apps/api/src/agent/mock-agent-sdk.ts
+++ b/apps/api/src/agent/mock-agent-sdk.ts
@@ -1,0 +1,146 @@
+/**
+ * Mock Agent SDK that replaces @anthropic-ai/claude-agent-sdk for E2E tests.
+ *
+ * Activated via MOCK_AGENT=true environment flag.
+ * Yields scripted message sequences following the real SDK's async generator pattern:
+ *   system init → stream_event text deltas → assistant complete → result
+ */
+
+export interface MockScenario {
+  messages: MockMessage[];
+}
+
+export type MockMessage =
+  | { type: "system"; subtype: "init"; session_id: string }
+  | {
+      type: "stream_event";
+      event: {
+        type: "content_block_delta";
+        delta:
+          | { type: "text_delta"; text: string }
+          | { type: "thinking_delta"; thinking: string };
+      };
+    }
+  | {
+      type: "assistant";
+      message: {
+        content: Array<
+          | { type: "text"; text: string }
+          | { type: "tool_use"; id: string; name: string; input: unknown }
+        >;
+      };
+    }
+  | {
+      type: "result";
+      subtype: "success" | "error";
+      result: string;
+      is_error: boolean;
+    };
+
+const DEFAULT_RESPONSE_TEXT =
+  "I'd be happy to help you write a PRD. Let me ask you some questions to understand your project better.";
+
+/** Default scenario: simple text response. */
+const defaultScenario: MockScenario = {
+  messages: [
+    { type: "system", subtype: "init", session_id: "mock-session-001" },
+    {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: DEFAULT_RESPONSE_TEXT },
+      },
+    },
+    {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: DEFAULT_RESPONSE_TEXT }],
+      },
+    },
+    {
+      type: "result",
+      subtype: "success",
+      result: DEFAULT_RESPONSE_TEXT,
+      is_error: false,
+    },
+  ],
+};
+
+/** Registry of scenarios by name. Tests can register custom scenarios. */
+const scenarios = new Map<string, MockScenario>([
+  ["default", defaultScenario],
+]);
+
+/** The scenario to use for the next query call. Resets to "default" after use. */
+let activeScenarioName = "default";
+
+/** Register a custom scenario for E2E tests. */
+export function registerScenario(name: string, scenario: MockScenario): void {
+  scenarios.set(name, scenario);
+}
+
+/** Set which scenario the next query() call will use. */
+export function setActiveScenario(name: string): void {
+  activeScenarioName = name;
+}
+
+/** Reset the mock state. */
+export function resetMock(): void {
+  activeScenarioName = "default";
+  // Keep only the default scenario
+  for (const key of scenarios.keys()) {
+    if (key !== "default") scenarios.delete(key);
+  }
+}
+
+/**
+ * Mock query() — yields scripted messages from the active scenario.
+ * Returns an async generator with the same interface as the real SDK's Query.
+ */
+export function query(_opts: unknown): AsyncGenerator<MockMessage, void> & {
+  interrupt: () => Promise<void>;
+  setPermissionMode: () => Promise<void>;
+  setModel: () => Promise<void>;
+  setMaxThinkingTokens: () => Promise<void>;
+  initializationResult: () => Promise<unknown>;
+} {
+  const scenario = scenarios.get(activeScenarioName) ?? defaultScenario;
+
+  const gen = (async function* () {
+    for (const msg of scenario.messages) {
+      // Small delay to simulate realistic streaming
+      await new Promise((r) => setTimeout(r, 5));
+      yield msg;
+    }
+  })() as any;
+
+  // Add required Query interface methods
+  gen.interrupt = async () => {};
+  gen.setPermissionMode = async () => {};
+  gen.setModel = async () => {};
+  gen.setMaxThinkingTokens = async () => {};
+  gen.initializationResult = async () => ({});
+
+  return gen;
+}
+
+/**
+ * Mock tool() — returns a tool definition object.
+ * The handler is preserved so the agent-service can still call it,
+ * but the mock query() won't invoke tool calls unless the scenario includes them.
+ */
+export function tool(
+  name: string,
+  description: string,
+  schema: unknown,
+  handler: (...args: unknown[]) => unknown
+) {
+  return { name, description, schema, handler };
+}
+
+/**
+ * Mock createSdkMcpServer() — returns the options as a pass-through.
+ */
+export function createSdkMcpServer(opts: unknown) {
+  return opts;
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import type { Db } from "@min-claude/db";
 import { projectRoutes } from "./routes/projects";
 import { prdRoutes } from "./routes/prds";
 import { chatRoutes } from "./routes/chat";
+import { mockRoutes } from "./routes/mock";
 import type { WsHub } from "./ws/hub";
 import type { AskUserBridge } from "./agent/ask-user-bridge";
 
@@ -19,6 +20,11 @@ export function app(db: Db, hub?: WsHub, bridge?: AskUserBridge) {
 
   if (hub && bridge) {
     app.route("/api/prds", chatRoutes(db, hub, bridge));
+  }
+
+  // Mock control routes — only available when MOCK_AGENT=true
+  if (process.env.MOCK_AGENT === "true") {
+    app.route("/api/mock", mockRoutes());
   }
 
   return app;

--- a/apps/api/src/routes/mock.ts
+++ b/apps/api/src/routes/mock.ts
@@ -1,0 +1,31 @@
+/**
+ * Mock control routes — only available when MOCK_AGENT=true.
+ * Allows E2E tests to register scenarios and control mock behavior.
+ */
+import { Hono } from "hono";
+import {
+  registerScenario,
+  setActiveScenario,
+  resetMock,
+  type MockScenario,
+} from "../agent/mock-agent-sdk";
+
+export function mockRoutes() {
+  const router = new Hono();
+
+  /** POST /api/mock/scenario — register and activate a scenario */
+  router.post("/scenario", async (c) => {
+    const body = await c.req.json<{ name: string; scenario: MockScenario }>();
+    registerScenario(body.name, body.scenario);
+    setActiveScenario(body.name);
+    return c.json({ ok: true });
+  });
+
+  /** POST /api/mock/reset — reset mock state to defaults */
+  router.post("/reset", (c) => {
+    resetMock();
+    return c.json({ ok: true });
+  });
+
+  return router;
+}

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@min-claude/e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from "@playwright/test";
+
+const API_PORT = 3001;
+const WEB_PORT = 3000;
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+
+  use: {
+    baseURL: `http://localhost:${WEB_PORT}`,
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+
+  webServer: [
+    {
+      command: `MOCK_AGENT=true bun run --hot src/index.ts`,
+      cwd: "../api",
+      port: API_PORT,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        MOCK_AGENT: "true",
+        PORT: String(API_PORT),
+      },
+    },
+    {
+      command: "bun run dev",
+      cwd: "../web",
+      port: WEB_PORT,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/apps/e2e/tests/smoke.spec.ts
+++ b/apps/e2e/tests/smoke.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage loads and displays default message", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByText("Select a project to get started")
+  ).toBeVisible();
+});
+
+test("API health endpoint responds", async ({ request }) => {
+  const response = await request.get("http://localhost:3001/health");
+  expect(response.ok()).toBeTruthy();
+  const body = await response.json();
+  expect(body.status).toBe("ok");
+});

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,14 @@
         "typescript": "^5.7.0",
       },
     },
+    "apps/e2e": {
+      "name": "@min-claude/e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "typescript": "^5.7.0",
+      },
+    },
     "apps/web": {
       "name": "@min-claude/web",
       "version": "0.0.0",
@@ -307,6 +315,8 @@
 
     "@min-claude/db": ["@min-claude/db@workspace:packages/db"],
 
+    "@min-claude/e2e": ["@min-claude/e2e@workspace:apps/e2e"],
+
     "@min-claude/shared": ["@min-claude/shared@workspace:packages/shared"],
 
     "@min-claude/web": ["@min-claude/web@workspace:apps/web"],
@@ -354,6 +364,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@petamoriken/float16": ["@petamoriken/float16@3.9.3", "", {}, "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -947,6 +959,8 @@
 
     "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
@@ -1360,6 +1374,10 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,10 @@
     },
     "db:migrate": {
       "cache": false
+    },
+    "test:e2e": {
+      "cache": false,
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Creates `apps/e2e` Turborepo workspace with Playwright for E2E testing
- Adds mock Agent SDK module (`mock-agent-sdk.ts`) that yields scripted async message generators following the real SDK pattern: `system` init → `stream_event` text deltas → `assistant` complete → `result`
- Adds `agent-sdk.ts` adapter that switches between real and mock SDK via `MOCK_AGENT=true` env flag
- Adds mock control routes (`/api/mock/scenario`, `/api/mock/reset`) for E2E test scenario setup
- Configures `playwright.config.ts` to start both API (port 3001, with mocked SDK) and Next.js (port 3000)
- Adds `test:e2e` turbo task
- Includes smoke tests: homepage loads + API health endpoint responds

Closes #19

## Test plan
- [x] `turbo run test` — all 103 unit tests pass
- [x] `turbo run typecheck` — all packages type check cleanly
- [x] `turbo run test:e2e` — both smoke tests pass
- [x] Playwright starts both API (with MOCK_AGENT=true) and Next.js dev server
- [x] Smoke test navigates to homepage and asserts "Select a project to get started"
- [x] Smoke test verifies API health endpoint responds with `{ status: "ok" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test suite with Playwright configuration and smoke tests for homepage and API health verification.

* **New Features**
  * Added mock agent adapter with conditional environment-based initialization.
  * Added mock control API endpoints for scenario registration and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->